### PR TITLE
Fix typo in the "Object Method" section (v8)

### DIFF
--- a/pages/docs/manual/v8.0.0/bind-to-js-function.mdx
+++ b/pages/docs/manual/v8.0.0/bind-to-js-function.mdx
@@ -103,7 +103,7 @@ MyGame.draw(10, 20, undefined);
 
 ## Object Method
 
-Functions attached to a JS objects (other than JS modules) require a special way of binding to them, using `bs.send`:
+Functions attached to JS objects (other than JS modules) require a special way of binding to them, using `bs.send`:
 
 <CodeTab labels={["Reason (Old Syntax)", "ML (Older Syntax)", "JS Output"]}>
 


### PR DESCRIPTION
"to a JS objects" → "to JS objects"